### PR TITLE
Detect when _LIST_ is empty

### DIFF
--- a/mysql_type/__init__.py
+++ b/mysql_type/__init__.py
@@ -96,6 +96,8 @@ def execute(c: CursorType, sql: str, *args: Any) -> UntypedResult:
                     raise Exception("Number of _LIST_ arguments do not match")
                 if isinstance(a, list):
                     flatargs += a
+                    if not a:
+                        return "null"
                     return ", ".join(['%s']*len(a))
                 flatargs.append(a)
         sql = re.sub("_LIST_", replace_arg, sql)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='mysql-type',
-    version='0.1.4',
+    version='0.1.5',
     packages=['mysql_type'],
     url='https://github.com/antialize/py-mysql-type',
     author='Jakob Truelsen',


### PR DESCRIPTION
I am not entirely sure if there are valid situations where `_LIST_` is empty.

However, `SELECT 1 WHERE 2 IN (_LIST_)` results in a syntax error, if `_LIST_` is empty:

```
#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1
```