### PR TITLE
Allow _LIST_ values to be tuples

### DIFF
--- a/mysql_type/__init__.py
+++ b/mysql_type/__init__.py
@@ -80,7 +80,7 @@ def execute(c: CursorType, sql: str, *args: Any) -> UntypedResult:
 
     Arguments in the query are expected to be presented as %s or _LIST_
     . For list arguments the coresponding entry in args is assumed to be a list
-    and the _LIST_ in the query is replaced by %s,%s,...,%s with where
+    or a tuple and the _LIST_ in the query is replaced by %s,%s,...,%s with where
     the number of $s's is equal to the list length
     """
     if "_LIST_" not in sql:
@@ -94,6 +94,8 @@ def execute(c: CursorType, sql: str, *args: Any) -> UntypedResult:
                 a = rargs.pop()
                 if a is None:
                     raise Exception("Number of _LIST_ arguments do not match")
+                if isinstance(a, tuple):
+                    a = list(a)
                 if isinstance(a, list):
                     flatargs += a
                     if not a:
@@ -103,7 +105,7 @@ def execute(c: CursorType, sql: str, *args: Any) -> UntypedResult:
         sql = re.sub("_LIST_", replace_arg, sql)
         while rargs:
             a = rargs.pop()
-            if isinstance(a, list):
+            if isinstance(a, list | tuple):
                 raise Exception("Number of _LIST_ arguments do not match")
             flatargs.append(a)
         c.execute(sql, flatargs)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='mysql-type',
-    version='0.1.5',
+    version='0.1.6',
     packages=['mysql_type'],
     url='https://github.com/antialize/py-mysql-type',
     author='Jakob Truelsen',


### PR DESCRIPTION
Sometimes tuples are used as a read-only version of lists. This commit changes the library such that users can supply such read-only lists as `_LIST_` values without having to convert them to `list` when calling `execute`.